### PR TITLE
use openjdk-8-jdk-headless and https for dl.bintray.com

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -39,7 +39,7 @@ title: Downloads
                 <a class="dlbutton" href="https://dl.bintray.com/rundeck/rundeck-deb/{{site.rd_deb_name}}" title="via bintray.com">{{site.rd_deb_name}}</a>
                 </p>
                 <p>Execute:</p>
-                <div style="margin-left:2em;"><code>apt-get install openjdk-8-jdk</code></div>
+                <div style="margin-left:2em;"><code>apt-get install openjdk-8-jdk-headless</code></div>
                 <div style="margin-left:2em;"><code>dpkg -i {{site.rd_deb_name}}</code></div>
                 
                 </div>

--- a/downloads.html
+++ b/downloads.html
@@ -24,7 +24,7 @@ title: Downloads
         <div>
 
             <p>
-            <a class="dlbutton" href="http://dl.bintray.com/rundeck/rundeck-maven/{{site.rd_war_name}}" title="via bintray.com">{{site.rd_war_name}}</a>
+            <a class="dlbutton" href="https://dl.bintray.com/rundeck/rundeck-maven/{{site.rd_war_name}}" title="via bintray.com">{{site.rd_war_name}}</a>
             </p>
                 <p>Put it in a directory named <code>~/rundeck</code></p>
                 <p>Execute:</p>
@@ -36,7 +36,7 @@ title: Downloads
 
               <div>
                 <p>
-                <a class="dlbutton" href="http://dl.bintray.com/rundeck/rundeck-deb/{{site.rd_deb_name}}" title="via bintray.com">{{site.rd_deb_name}}</a>
+                <a class="dlbutton" href="https://dl.bintray.com/rundeck/rundeck-deb/{{site.rd_deb_name}}" title="via bintray.com">{{site.rd_deb_name}}</a>
                 </p>
                 <p>Execute:</p>
                 <div style="margin-left:2em;"><code>apt-get install openjdk-8-jdk</code></div>


### PR DESCRIPTION
openjdk-8-jdk without -headless will pull X11/gui dependencies in debian/ubuntu, installing to 383 MB instead of 141 MB and I speculate alot of unneeded packages. I haven't seen downsides using the headless jdk.

I also changed the dl.bintray.com links to https, as normal bintray.com links, the domain is reachable via ssl too.